### PR TITLE
Change to ignore unusing records when there is more than 9

### DIFF
--- a/apps/flink/source/core/app/src/main/java/com/lightbend/fdp/sample/flink/app/TaxiRide.java
+++ b/apps/flink/source/core/app/src/main/java/com/lightbend/fdp/sample/flink/app/TaxiRide.java
@@ -92,7 +92,7 @@ public class TaxiRide implements Comparable<TaxiRide> {
 	public static TaxiRide fromString(String line) {
 
 		String[] tokens = line.split(",");
-		if (tokens.length != 9) {
+		if (tokens.length < 9) {
 			throw new RuntimeException("Invalid record: " + line);
 		}
 


### PR DESCRIPTION
Hello, this issue is found from issue #8 .
When I run `ingest`, it causes issue of 'Invalid record', because currently parser define record as invalid when there are more/less than 9 items but when I downloaded record file from link, it includes 11 items.
I'm not sure about history of this, but this sample application is using 9 items, so how about to change ignoring unusing file instead of defining this as invalid?
